### PR TITLE
#21 Feature add tooltip to map markers to indicate name o…

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -302,7 +302,7 @@ function initMap(results) {
     return; // exit if there is no data for the map
   }
   const { Landmarks, mainGeoCoord } = results;
-
+  const nameOfPlace = $('#name-of-place').text();
   const icons = {
     centerIcon: 'minImages/flag-red.png',
     landmarkIcon: 'minImages/flag-blue.png',
@@ -326,6 +326,7 @@ function initMap(results) {
     animation: google.maps.Animation.BOUNCE,
     icon: icons.centerIcon,
     map,
+    title: nameOfPlace,
   });
 
   google.maps.event.addListener(centerMarker, 'click', () => {
@@ -343,6 +344,7 @@ function initMap(results) {
       animation: google.maps.Animation.DROP,
       icon: icons.landmarkIcon,
       map,
+      title: placeName,
     });
 
     // Add a click event to each marker.
@@ -408,7 +410,7 @@ class TemperatureConverter {
       return getWeatherInfoOfSearchedPlace({ Latitude, Longitude }, metricSystem);
     })
       .then((res) => {
-        this.setCurrentMetricSystem(metricSystem); // set currentMetricSystem to local storage.
+        this.setCurrentMetricSystem(metricSystem); // set new metricSystem to local storage.
         let metricSystemSuffix; // Use to suffix the temperature according to metric system
         if (metricSystem === 'celsius') {
           metricSystemSuffix = 'C';

--- a/js/main.js
+++ b/js/main.js
@@ -302,7 +302,7 @@ function initMap(results) {
     return; // exit if there is no data for the map
   }
   const { Landmarks, mainGeoCoord } = results;
-
+  const nameOfPlace = $('#name-of-place').text();
   const icons = {
     centerIcon: 'minImages/flag-red.png',
     landmarkIcon: 'minImages/flag-blue.png',
@@ -326,6 +326,7 @@ function initMap(results) {
     animation: google.maps.Animation.BOUNCE,
     icon: icons.centerIcon,
     map,
+    title: nameOfPlace,
   });
 
   google.maps.event.addListener(centerMarker, 'click', () => {
@@ -343,6 +344,7 @@ function initMap(results) {
       animation: google.maps.Animation.DROP,
       icon: icons.landmarkIcon,
       map,
+      title: placeName,
     });
 
     // Add a click event to each marker.


### PR DESCRIPTION
**What does the PR do?**

Add tooltips to the map markers 

**Description of tasks to be completed**

- Add tooltip to the map markers to indicate the name of the landmark which the are pointed to.

**How should this be manually tested?**

- After cloning the repo, `cd` into it and run` npm install`
- After that, run the command `gulp` and it should be able to open up the page on your web browser
- After page has loaded type in the name of any place of choice and `click` on the `submit button` and the map should load with the markers in place.
- `Hover` the mouse on each of the markers and a tooltip should appear with the name of the place which the marker points

**Any background context you want to provide?**

Testers should should have internet connection on.

**What are the relevant pivotal tracker stories?**

#3